### PR TITLE
Field is an Uuid field not a primary field

### DIFF
--- a/config/field/properties.php
+++ b/config/field/properties.php
@@ -82,7 +82,7 @@ return [
             'visible', 'fillable', 'required',
         ],
         'fields' => [
-            'id' => UniqueId::class,
+            'id' => Uuid::class,
             'reversed' => Reversed\HasOne::class,
         ],
         'templates' => [


### PR DESCRIPTION
Update the field type for OneToOneUuid.

Bug : 
On the migration we had an integer that was generated instead of an uuid.

